### PR TITLE
fix syntex like `${//}` into `${0://}`

### DIFF
--- a/src/snippets/javascript.json
+++ b/src/snippets/javascript.json
@@ -499,7 +499,7 @@
     "scrollBehavior": {
         "prefix": "scrollBehavior",
         "body": [
-            "scrollBehavior (to, from, savedPosition){\n\t${//return desired position}\n\t$0\n}"
+            "scrollBehavior (to, from, savedPosition){\n\t${0://return desired position}\n\t$1\n}"
         ],
         "description": "[router]Scroll Behavior(this feature only works in HTML5 history mode)"
     },
@@ -583,28 +583,28 @@
     "router.beforeEach": {
         "prefix": "router.beforeEach",
         "body": [
-            "router.beforeEach((to, from, next) => {\n\t${//to and from are Route Object,next() must be called to resolve the hook}\n\t$0\n})"
+            "router.beforeEach((to, from, next) => {\n\t${0://to and from are Route Object,next() must be called to resolve the hook}\n\t$1\n})"
         ],
         "description": "[router] register global before guards"
     },
     "router.afterEach": {
         "prefix": "router.afterEach",
         "body": [
-            "router.afterEach( ${route} => {\n\t${//these hooks do not get a next function and cannot affect the navigation}\n\t$0\n})"
+            "router.afterEach( ${route} => {\n\t${0://these hooks do not get a next function and cannot affect the navigation}\n\t$1\n})"
         ],
         "description": "[router] register global after guards"
     },
     "beforeRouteEnter": {
         "prefix": "beforeRouteEnter",
         "body": [
-            "beforeRouteEnter((to, from, next) => {\n\t${//does NOT have access to `this` component instance}\n\t$0\n})"
+            "beforeRouteEnter((to, from, next) => {\n\t${0://does NOT have access to `this` component instance}\n\t$1\n})"
         ],
         "description": "[router]define beforeEnter guards directly on a route's configuration object:"
     },
     "beforeRouteLeave": {
         "prefix": "beforeRouteLeave",
         "body": [
-            "beforeRouteLeave((to, from, next) => {\n\t${//has access to `this` component instance}\n\t$0\n})"
+            "beforeRouteLeave((to, from, next) => {\n\t${0://has access to `this` component instance}\n\t$1\n})"
         ],
         "description": "[router]define beforeEnter guards directly on a route's configuration object:"
     },


### PR DESCRIPTION
## my vscode
版本 1.24.1
提交 24f62626b222e9a8313213fb64b10d741a326288
日期 2018-06-13T17:52:25.282Z
Shell 1.7.12
渲染器 58.0.3029.110
Node 7.9.0
架构 ia32

## vscode packages
installed `vetur` and `vuehelper`

## bug
Every time when i type in `bre` for `beforeRouteEnter`
**I got code like below:**
![image](https://user-images.githubusercontent.com/13229398/41951244-6e84cca8-79fc-11e8-87e2-a003d5074c64.png)

## fix suggestion
Then I found that Vuehelper make snippets for that, so I changed some code, Now it is ok!
---
Hope to merged into master branch for help people who has the same problem as me!